### PR TITLE
Fix select with optgroups

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -661,14 +661,14 @@
 
       // Add initial multiple selections.
       if (multiple) {
-        $select.find("option:selected:not(:disabled)").each(function () {
-          var index = $(this).index();
-
-          toggleEntryFromArray(valuesSelected, index, $select);
-          options.find("li").eq(index).find(":checkbox").prop("checked", true);
+          $select.find("option").each(function (index) {
+              if ($(this).is('option:selected:not(:disabled)')) {
+                  toggleEntryFromArray(valuesSelected, index, $select);
+                  options.find("li:not(.optgroup)").eq(index).find(":checkbox").prop("checked", true);
+              }
         });
       }
-
+      
       /**
        * Make option as selected and scroll to selected position
        * @param {jQuery} collection  Select options jQuery element


### PR DESCRIPTION
This fixes setting checked on select options within optgroups.

The problem with the original each() is, that the index is relative to the containing optgroup. By iterating over every option, checking for selected and taking the index within all options the corresponding li element of the generated optgroup-options can be properly addressed.