### PR TITLE
Carousel mobile tapping/vertical scrolling

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -340,7 +340,9 @@
         }
 
         function tap(e) {
-          e.preventDefault();
+          if (e.type === 'mousedown') {
+            e.preventDefault();
+          }
           pressed = true;
           dragged = false;
           vertical_dragged = false;


### PR DESCRIPTION
The tap swipe up or swipe down events within the carousel are not propagating. It is also not possible to tap indicators or any controls/links contained inside the carousel items.

Apply this patch to restore the vertical scroll behaviour on mobile devices but leave it as is on desktop devices.